### PR TITLE
added fortmatic, fixed ledger timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -7,7 +7,8 @@ const {
   abis,
   SWAP_LEGACY_CONTRACT_ADDRESS,
 } = require('../constants')
-const { getLogs, BlockTracker } = require('../utils/gethRead')
+const BlockTracker = require('../utils/blockTracker')
+const { getLogs } = require('../utils/gethRead')
 
 const provider = new ethers.providers.JsonRpcProvider(AIRSWAP_GETH_NODE_ADDRESS)
 

--- a/src/ledger/index.js
+++ b/src/ledger/index.js
@@ -1,16 +1,16 @@
 const _ = require('lodash')
 const ProviderEngine = require('web3-provider-engine')
 const RpcSubprovider = require('web3-provider-engine/subproviders/rpc')
-const AppEth = require('@ledgerhq/hw-app-eth/lib/Eth')
-const TransportU2F = require('@ledgerhq/hw-transport-u2f')
+const { default: AppEth } = require('@ledgerhq/hw-app-eth/lib/Eth')
+const { default: TransportU2F } = require('@ledgerhq/hw-transport-u2f')
 const HookedWalletSubprovider = require('web3-provider-engine/subproviders/hooked-wallet')
 const stripHexPrefix = require('strip-hex-prefix')
 const EthereumTx = require('ethereumjs-tx')
-
 const { NETWORK, AIRSWAP_GETH_NODE_ADDRESS } = require('../constants')
 
 const getLedgerAccount = async subPath => {
   const transport = await TransportU2F.create(10000, 10000)
+
   const eth = new AppEth(transport)
   const path = `${subPath}`
   const addressPromise = eth.getAddress(path, false, true)
@@ -175,7 +175,7 @@ function createLedgerSubprovider(getTransport, options) {
     }
   }
 
-  const ledgerTimeout = 3000
+  const ledgerTimeout = 30000
 
   const subprovider = new HookedWalletSubprovider({
     getAccounts: callback => {

--- a/src/utils/blockTracker.js
+++ b/src/utils/blockTracker.js
@@ -1,0 +1,36 @@
+const _ = require('lodash')
+const { fetchBlock, fetchLatestBlock } = require('./gethRead')
+
+class BlockTracker {
+  constructor(onBlock, interval = 3000) {
+    this.interval = interval
+    this.onBlock = onBlock || _.identity
+    this.blocks = {}
+    this.init()
+  }
+  async init() {
+    const block = await fetchLatestBlock(true)
+    this.blocks[block.number] = block
+    this.onBlock(block)
+    this.pollForNextBlock()
+  }
+  getSortedBlocks() {
+    return _.sortBy(_.values(this.blocks), 'number')
+  }
+  async pollForNextBlock() {
+    const currentBlockNumber = _.get(_.last(this.getSortedBlocks()), 'number')
+    let block
+    try {
+      block = await fetchBlock(currentBlockNumber + 1)
+      if (block) {
+        this.blocks[block.number] = block
+        this.onBlock(block)
+      }
+    } catch (e) {
+      console.log(`didnt get block (threw error) ${currentBlockNumber}`, e)
+    }
+    setTimeout(this.pollForNextBlock.bind(this), this.interval)
+  }
+}
+
+module.exports = BlockTracker

--- a/src/utils/gethRead.js
+++ b/src/utils/gethRead.js
@@ -90,40 +90,8 @@ function getLogs(params) {
   return send(method)
 }
 
-class BlockTracker {
-  constructor(onBlock, interval = 3000) {
-    this.interval = interval
-    this.onBlock = onBlock || _.identity
-    this.blocks = {}
-    this.init()
-  }
-  async init() {
-    const block = await fetchLatestBlock(true)
-    this.blocks[block.number] = block
-    this.onBlock(block)
-    this.pollForNextBlock()
-  }
-  getSortedBlocks() {
-    return _.sortBy(_.values(this.blocks), 'number')
-  }
-  async pollForNextBlock() {
-    const currentBlockNumber = _.get(_.last(this.getSortedBlocks()), 'number')
-    let block
-    try {
-      block = await fetchBlock(currentBlockNumber + 1)
-      if (block) {
-        this.blocks[block.number] = block
-        this.onBlock(block)
-      }
-    } catch (e) {
-      console.log(`didnt get block (threw error) ${currentBlockNumber}`, e)
-    }
-    setTimeout(this.pollForNextBlock.bind(this), this.interval)
-  }
-}
-
 function hexToInt(hexInt) {
   return Number.parseInt(hexInt, 16)
 }
 
-module.exports = { fetchBlock, getLogs, BlockTracker }
+module.exports = { fetchBlock, fetchLatestBlock, getLogs }

--- a/src/wallet/getSigner.js
+++ b/src/wallet/getSigner.js
@@ -95,9 +95,7 @@ function getSigner(params, walletActions = {}) {
 
     const tempProvider = new ethers.providers.Web3Provider(web3Provider)
     const signer = tempProvider.getSigner()
-    const s = traceMethodCalls(signer, walletActions)
-    window.s = s
-    return s
+    return traceMethodCalls(signer, walletActions)
   }
 }
 

--- a/src/wallet/redux/middleware.js
+++ b/src/wallet/redux/middleware.js
@@ -167,7 +167,6 @@ function connectFortmatic(store) {
   const fm = new Fortmatic(FORTMATIC_ID)
   const provider = fm.getProvider()
   provider.enable().then(() => {
-    provider.isMetamask = true //eslint-disable-line
     signer = getSigner({ web3Provider: provider }, walletActions)
     const addressPromise = signer.getAddress()
     addressPromise

--- a/src/wallet/redux/middleware.js
+++ b/src/wallet/redux/middleware.js
@@ -167,6 +167,7 @@ function connectFortmatic(store) {
   const fm = new Fortmatic(FORTMATIC_ID)
   const provider = fm.getProvider()
   provider.enable().then(() => {
+    provider.isMetamask = true //eslint-disable-line
     signer = getSigner({ web3Provider: provider }, walletActions)
     const addressPromise = signer.getAddress()
     addressPromise

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,38 +1013,51 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@ledgerhq/devices@^4.55.0":
-  version "4.55.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.55.0.tgz#c1fb7e33d38f2352f4991ea9fa4987e90238ee21"
+"@ledgerhq/devices@^4.61.0":
+  version "4.61.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.61.0.tgz#12045bb25ffdc43de5ce97770008a605675de246"
+  integrity sha512-ZBXtV4JFOSvxwfr9PwoAfOdh9Qb/nIPpMR69uG0BwCkz6KzFyJWinsJvf+wFBQmnxDJKcPz2eWrCEL/viQ0HOQ==
   dependencies:
-    "@ledgerhq/errors" "^4.55.0"
+    "@ledgerhq/errors" "^4.61.0"
+    "@ledgerhq/logs" "^4.61.0"
+    rxjs "^6.5.2"
 
-"@ledgerhq/errors@^4.55.0":
-  version "4.55.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.55.0.tgz#5fbef730abbcf3fd8a37838f37a08eada11720fd"
+"@ledgerhq/errors@^4.61.0":
+  version "4.61.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.61.0.tgz#dca01039453d2bf7b1e4fe866d55e82585b77567"
+  integrity sha512-sEbAF7H/0EL8WiQ+m2qaZFzIJjtrXUFaxHyI4J/FSgK3uszDAVcnXwetq7TFOswZtPS2u2g/5oa1/iuoNVKwXQ==
 
 "@ledgerhq/hw-app-eth@^4.55.0":
-  version "4.55.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.55.0.tgz#fbaf866dac12a58b0801995b1700f0ac02ca6c44"
+  version "4.61.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.61.0.tgz#65c41abe7c55bcd4dba4a506e3297440e58e8ff0"
+  integrity sha512-z9/ByCuP/BgpGThCtHshPlyTRo4YZMk+DV5BXUWg5PugGVatlilrP95EQN1hEaVDFSUzp5mS+eGtHSpo6uWX5Q==
   dependencies:
-    "@ledgerhq/errors" "^4.55.0"
-    "@ledgerhq/hw-transport" "^4.55.0"
+    "@ledgerhq/errors" "^4.61.0"
+    "@ledgerhq/hw-transport" "^4.61.0"
 
 "@ledgerhq/hw-transport-u2f@^4.55.0":
-  version "4.55.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.55.0.tgz#3dc318801adf900a9a673420fa741ad6dfc3ce89"
+  version "4.61.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.61.0.tgz#791c1587ff2491442ad120249d5c802549ddb1d5"
+  integrity sha512-qQlELJcwdtheE2WmPPVZo43F+Pa1IppzsXID8j89VVjwAKk22uCI0a75pyPG3Of2H07BZVab+jqL3fxzPEMCPw==
   dependencies:
-    "@ledgerhq/errors" "^4.55.0"
-    "@ledgerhq/hw-transport" "^4.55.0"
+    "@ledgerhq/errors" "^4.61.0"
+    "@ledgerhq/hw-transport" "^4.61.0"
+    "@ledgerhq/logs" "^4.61.0"
     u2f-api "0.2.7"
 
-"@ledgerhq/hw-transport@^4.55.0":
-  version "4.55.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.55.0.tgz#76249204d9571245ff3efb354a618f94b2634f33"
+"@ledgerhq/hw-transport@^4.61.0":
+  version "4.61.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.61.0.tgz#709d9ec3c0c536181374a438db27e635059d3328"
+  integrity sha512-jsITF3HAttITBVKZOEASeTSBENbnrhcZmyxhiI1ijRFqDSEAPp7LuttNnI1d99301/4dWZV9NSe40naBsCJHXQ==
   dependencies:
-    "@ledgerhq/devices" "^4.55.0"
-    "@ledgerhq/errors" "^4.55.0"
+    "@ledgerhq/devices" "^4.61.0"
+    "@ledgerhq/errors" "^4.61.0"
     events "^3.0.0"
+
+"@ledgerhq/logs@^4.61.0":
+  version "4.61.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.61.0.tgz#bbcba49d7a7a4e20d6584bbfc10ed93b212c804c"
+  integrity sha512-AObEnA+tgzKEwY306i6FOT/hlc+zjF817Bty/IxG3f2wPJFRK9cJuD3Ijl4pfJP2pt7KubN4YbRGXREXhEsknQ==
 
 "@mattiasbuelens/web-streams-polyfill@^0.3.1":
   version "0.3.1"
@@ -7067,6 +7080,13 @@ rx-lite@^3.1.2:
 rxjs@^6.3.3:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This PR adds the Fortmatic provider.
It also adds low-level geth RPC overrides into the `traceMethodCalls` function inside the `getSigner` module. Ethers.js tries to be too clever and makes abstraction hard, so this is my way of side-stepping that cleverness with standard functions. Every single provider needs to be tested before this is shipped to production. I have tested them myself, but would prefer some redundancy.

Blocktracker is also moved into its own module. This is in preparation for some refactoring in the way events are handled.  

Finally, the ledger node_module is also updated. The 3 second timeout issue everyone was experiencing seems to be fixed in the latest version.