### PR TITLE
Upgrade ethers.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     ]
   },
   "peerDependencies": {
-    "bignumber.js": "^4.1.0",
     "redux": "^3.7.2",
     "reselect": "^3.0.1"
   },
@@ -86,7 +85,7 @@
     "@portis/web3": "^2.0.0-beta.16",
     "axios": "^0.18.0",
     "ethereumjs-wallet": "^0.6.3",
-    "ethers": "^4.0.25",
+    "ethers": "^4.0.31",
     "ethjs-provider-http": "^0.1.6",
     "eventsource": "^1.0.7",
     "fortmatic": "^0.7.4",

--- a/src/HDW/redux/middleware.js
+++ b/src/HDW/redux/middleware.js
@@ -82,7 +82,20 @@ export default function HDWMiddleware(store) {
         getHWDAddresses(store, offset)
         break
       case 'SET_HDW_SUBPATH':
-        store.dispatch(actions.initializeHDW(walletType, action.path))
+        path = action.path
+        store.dispatch({
+          type: 'GET_HDW_CHAIN_KEY',
+          walletType,
+          path,
+          resolve: response => {
+            publicKey = response.publicKey
+            chainCode = response.chainCode
+            getHWDAddresses(store, offset)
+          },
+          reject: err => {
+            rejectHDW(err)
+          },
+        })
         break
       case 'CONFIRM_HDW_PATH':
         resolveHDW({

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -4,7 +4,7 @@ const EventSource = require('eventsource')
 const fetch = require('isomorphic-fetch')
 const { REACT_APP_SERVER_URL, AIRSWAP_API_URL, AIRSWAP_HEADLESS_API_SSE, MAKER_STATS_URL } = require('../constants')
 
-const prefix = window.location.protocol
+const prefix = typeof window !== 'undefined' ? window.location.protocol : 'https:'
 
 function fetchRouterConnectedUsers() {
   return new Promise((resolve, reject) => {

--- a/src/protocolMessaging/index.js
+++ b/src/protocolMessaging/index.js
@@ -22,7 +22,8 @@ class Router {
     this.requireAuthentication = requireAuthentication
 
     const keyspaceSnippet = keyspace ? 'use_pgp=true&' : ''
-    const prefix = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const prefix = typeof window !== 'undefined' && window.location.protocol === 'http:' ? 'ws:' : 'wss:'
+
     // Set the websocket url based on environment
     this.socketUrl = `${prefix}${REACT_APP_SERVER_URL}websocket${requireAuthentication ? '' : '/nochallenge'}${`?${
       requireAuthentication ? keyspaceSnippet : ''

--- a/src/wallet/getSigner.js
+++ b/src/wallet/getSigner.js
@@ -30,15 +30,7 @@ function traceMethodCalls(obj, { startWalletAction, finishWalletAction }) {
         propKey === 'signMessage'
       ) {
         return function(...args) {
-          const addressPromise = new Promise((resolve, reject) =>
-            target.provider._sendAsync({ id: uuid(), method: 'eth_accounts' }, (err, resp) => {
-              if (err) {
-                reject(err)
-              } else {
-                resolve(_.first(_.get(resp, 'result')))
-              }
-            }),
-          )
+          const addressPromise = target.getAddress()
 
           return addressPromise.then(from => {
             const msg = ethUtil.bufferToHex(new Buffer(_.first(args), 'utf8'))
@@ -55,18 +47,6 @@ function traceMethodCalls(obj, { startWalletAction, finishWalletAction }) {
             result.finally(() => finishWalletAction(propKey, args))
             return result
           })
-        }
-      } else if (typeof target[propKey] === 'function' && propKey === 'getAddress') {
-        return function() {
-          return new Promise((resolve, reject) =>
-            target.provider._sendAsync({ id: uuid(), method: 'eth_accounts' }, (err, resp) => {
-              if (err) {
-                reject(err)
-              } else {
-                resolve(_.first(_.get(resp, 'result')))
-              }
-            }),
-          )
         }
       }
       return target[propKey]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3475,10 +3475,10 @@ ethereumjs-wallet@^0.6.3:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^4.0.25:
-  version "4.0.30"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.30.tgz#140653fd08adf2834bb2f3aceefa10d04205b47d"
-  integrity sha512-1a39Y+q5zTfrXCLndV+CHsTHq+T5/TvAx5y0S/PKd700C0lfU70CJnU7q89bd+4pIuWp05TkrEsrTj2dXhkcSA==
+ethers@^4.0.31:
+  version "4.0.31"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.31.tgz#50b066d8c74140944edfd2ad0a805162c30e3a20"
+  integrity sha512-S2zKBGvEBIng7hghAXZ9259xCkClyRr/bM0F297O3lAnC6sYjTHNIMtiqWmA89qieAIyzWUZn/aCLUslRlJFkw==
   dependencies:
     "@types/node" "^10.3.2"
     aes-js "3.0.0"


### PR DESCRIPTION
Changes:
  - upgrade ethers.js version
  - simplify custom getAddress RPC call (bug with hardcoded JSON RPC ID fixed in this ethers.js version, so it isn't necessary anymore)
  - fixed bug with use of undefined `window` var in node.js