### PR TITLE
Generalized balance tracking

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,8 @@
     "new-cap": "off",
     "import/no-named-as-default": "off",
     "react/require-default-props": "off",
-    "no-underscore-dangle": "off"
+    "no-underscore-dangle": "off",
+    "array-callback-return": "off"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/src/api/redux/middleware.js
+++ b/src/api/redux/middleware.js
@@ -1,40 +1,37 @@
 import * as api from '../index'
 import { makeMiddlewareHTTPFn } from '../../utils/redux/templates/http'
+import { IS_INSTANT } from '../../constants'
+import { selectors } from './reducers'
+import { addTrackedAddresses } from '../../deltaBalances/redux/actions'
+
+let connectedIntentsLength = 0
 
 export default function apiMiddleware(store) {
-  makeMiddlewareHTTPFn(api.fetchMaxQuotes, 'maxQuotes', store, { increment: 60 * 1000 * 2 })
-  makeMiddlewareHTTPFn(api.fetchQuotes, 'quotes', store, { increment: 1000 * 60 * 2 })
-  makeMiddlewareHTTPFn(api.fetchRouterConnectedUsers, 'connectedUsers', store, { increment: 60 * 1000 * 3 })
-  makeMiddlewareHTTPFn(api.fetchIndexerIntents, 'indexerIntents', store, { increment: 1000 * 60 * 60 })
+  const trackMakerTokens = connectedIntents => {
+    if (connectedIntents.length !== connectedIntentsLength) {
+      // only add new tracked addresses if the number of tracked intents changes
+      connectedIntentsLength = connectedIntents.length
+      const trackedAddresses = connectedIntents.map(({ makerAddress, makerToken }) => ({
+        address: makerAddress,
+        tokenAddress: makerToken,
+      }))
+      store.dispatch(addTrackedAddresses(trackedAddresses))
+    }
+  }
+
+  if (IS_INSTANT) {
+    makeMiddlewareHTTPFn(api.fetchRouterConnectedUsers, 'connectedUsers', store, { increment: 60 * 1000 * 3 })
+    makeMiddlewareHTTPFn(api.fetchIndexerIntents, 'indexerIntents', store, { increment: 1000 * 60 * 60 })
+  }
+
   return next => action => {
     switch (action.type) {
       default:
     }
 
-    // INCLUDED FOR EASY TESTING UNTIL THE FEATURE STABILIZES, WILL DELETE SOON
-    // const state = store.getState()
-    // console.log(
-    //   selectors.makeGetFormattedLiquidityByTokenPair(state)({
-    //     takerToken: ETH_ADDRESS,
-    //     makerToken: AST_CONTRACT_ADDRESS,
-    //   }),
-    //   selectors.makeGetHighestPriceByTokenPair(state)({
-    //     takerToken: ETH_ADDRESS,
-    //     makerToken: AST_CONTRACT_ADDRESS,
-    //   }),
-    //   selectors.makeGetLowestPriceByTokenPair(state)({
-    //     takerToken: ETH_ADDRESS,
-    //     makerToken: AST_CONTRACT_ADDRESS,
-    //   }),
-    //   selectors.makeGet24HourVolumeByTokenPair(state)({
-    //     takerToken: ETH_ADDRESS,
-    //     makerToken: AST_CONTRACT_ADDRESS,
-    //   }),
-    //   selectors.makeGet24HourTradesByTokenPair(state)({
-    //     takerToken: ETH_ADDRESS,
-    //     makerToken: AST_CONTRACT_ADDRESS,
-    //   }),
-    // )
-    return next(action)
+    next(action)
+    if (IS_INSTANT) {
+      trackMakerTokens(selectors.getConnectedIndexerIntents(store.getState()))
+    }
   }
 }

--- a/src/api/redux/reducers.js
+++ b/src/api/redux/reducers.js
@@ -8,7 +8,6 @@ import { makeHTTPReducer, makeHTTPSelectors } from '../../utils/redux/templates/
 import { selectors as tokenSelectors } from '../../tokens/redux'
 import { selectors as eventSelectors } from '../../events/redux'
 import { lowerCaseStringsInObject } from '../../utils/transformations'
-import { getConnectedWalletAddress } from '../../wallet/redux/reducers'
 
 const connectedUsers = makeHTTPReducer('connectedUsers')
 const indexerIntents = makeHTTPReducer('indexerIntents')
@@ -226,12 +225,6 @@ const makeGet24HourTradesByTokenPair = createSelector(
   },
 )
 
-const getTrackedAddresses = createSelector(
-  getConnectedWalletAddress,
-  getConnectedMakerAddressesWithIndexerIntents,
-  (walletAddress, makerAddresses) => _.uniq(_.compact([walletAddress, ...makerAddresses])),
-)
-
 export const selectors = {
   getAttemptedGettingConnectedUsers,
   getGettingConnectedUsers,
@@ -265,5 +258,4 @@ export const selectors = {
   makeGet24HourTradesByTokenPair,
   getFormattedQuotes,
   getMaxQuotes,
-  getTrackedAddresses,
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -263,6 +263,8 @@ const FORTMATIC_ID = (N => {
   }
 })(NETWORK)
 
+const IS_INSTANT = process.env.REACT_APP_INSTANT
+
 module.exports = {
   ENV,
   MAIN_ID,
@@ -310,4 +312,5 @@ module.exports = {
   NODESMITH_KEY,
   NODESMITH_URL,
   FORTMATIC_ID,
+  IS_INSTANT,
 }

--- a/src/deltaBalances/redux/actions.js
+++ b/src/deltaBalances/redux/actions.js
@@ -29,3 +29,14 @@ export const getAllAllowancesForConnectedAddress = address => ({
   type: 'GET_ALL_ALLOWANCES_FOR_CONNECTED_ADDRESS',
   address,
 })
+
+export const addTrackedAddress = ({ address, tokenAddress }) => ({
+  type: 'ADD_TRACKED_ADDRESS',
+  address,
+  tokenAddress,
+})
+
+export const addTrackedAddresses = trackedAddresses => ({
+  type: 'ADD_TRACKED_ADDRESSES',
+  trackedAddresses,
+})

--- a/src/events/redux/middleware.js
+++ b/src/events/redux/middleware.js
@@ -3,7 +3,7 @@ import * as ethers from 'ethers'
 import { abis, SWAP_LEGACY_CONTRACT_ADDRESS, ERC20abi } from '../../constants'
 import { makeEventActionTypes, makeEventFetchingActionsCreators } from '../../utils/redux/templates/event'
 import { selectors as blockTrackerSelectors } from '../../blockTracker/redux'
-import { selectors as apiSelectors } from '../../api/redux'
+import { selectors as deltaBalancesSelectors } from '../../deltaBalances/redux'
 import { selectors as eventSelectors } from './reducers'
 
 import * as gethRead from '../../utils/gethRead'
@@ -29,7 +29,7 @@ const initPollExchangeFills = _.once(store => {
 
 const pollERC20Transfers = (store, block) => {
   const state = store.getState()
-  const addresses = apiSelectors.getTrackedAddresses(state)
+  const addresses = deltaBalancesSelectors.getTrackedWalletAddresses(state)
   if (!addresses.length) {
     return null
   }

--- a/src/keySpace/redux/middleware.js
+++ b/src/keySpace/redux/middleware.js
@@ -4,6 +4,7 @@ import { formatErrorMessage } from '../../utils/transformations'
 import { selectors } from './reducers'
 import { getConnectedWalletAddress } from '../../wallet/redux/reducers'
 import { selectors as protocolMessagingSelectors } from '../../protocolMessaging/redux/reducers'
+import { IS_INSTANT } from '../../constants'
 
 let keySpace
 
@@ -30,7 +31,7 @@ export default function keySpaceMiddleware(store) {
   return next => action => {
     switch (action.type) {
       case 'CONNECTED_WALLET':
-        if (protocolMessagingSelectors.getRouterRequireAuth(store.getState())) {
+        if (protocolMessagingSelectors.getRouterRequireAuth(store.getState()) && IS_INSTANT) {
           store.dispatch({ type: 'INITIALIZE_KEYSPACE' })
         }
         break

--- a/src/protocolMessaging/redux/middleware.js
+++ b/src/protocolMessaging/redux/middleware.js
@@ -327,18 +327,6 @@ export default function routerMiddleware(store) {
         break
       default:
     }
-    // FOR TESTING SELECTED ORDER FUNCTIONALITY, WILL DELETE SOON
-    // const orderIds = protocolMessagingSelectors.getCurrentFrameAllOrderResponses(state).map(order => ({
-    //   ...selectCheckoutFrameOrder(order),
-    // }))
-    // const currentFrameSelectedOrder = protocolMessagingSelectors.getCurrentFrameSelectedOrder(state)
-    // if (currentFrameSelectedOrder) {
-    //   console.log('selected order', currentFrameSelectedOrder)
-    //   console.log('getCurrentFrameAllOrderResponses', protocolMessagingSelectors.getCurrentFrameAllOrderResponses(state))
-    //   console.log('state props ', protocolMessagingSelectors.getCurrentFrameStateSummaryProperties(state))
-    // } else if (orderIds.length) {
-    //   console.log(JSON.stringify(orderIds, null, 2))
-    // }
     return next(action)
   }
 }

--- a/src/protocolMessaging/redux/middleware.js
+++ b/src/protocolMessaging/redux/middleware.js
@@ -9,7 +9,7 @@ import { newCheckoutFrame } from './actions'
 import { fillOrder } from '../../swapLegacy/redux/actions'
 import { getKeySpace } from '../../keySpace/redux/actions'
 import { fetchSetDexIndexPrices } from '../../dexIndex/redux/actions'
-import { ETH_ADDRESS } from '../../constants'
+import { ETH_ADDRESS, IS_INSTANT } from '../../constants'
 import { Quote, Order } from '../../tcombTypes'
 
 async function initialzeRouter(store) {
@@ -285,7 +285,7 @@ export default function routerMiddleware(store) {
 
     switch (action.type) {
       case 'CONNECTED_WALLET':
-        if (!protocolMessagingSelectors.getRouterRequireAuth(state)) {
+        if (!protocolMessagingSelectors.getRouterRequireAuth(state) && IS_INSTANT) {
           const routerPromise = initialzeRouter(store).then(() => store.dispatch({ type: 'ROUTER_CONNECTED' }))
           routerPromise.catch(error => store.dispatch({ type: 'ERROR_CONNECTING_ROUTER', error }))
         }

--- a/src/utils/gethRead.js
+++ b/src/utils/gethRead.js
@@ -99,4 +99,12 @@ function hexToInt(hexInt) {
   return Number.parseInt(hexInt, 16)
 }
 
-module.exports = { fetchBlock, fetchLatestBlock, getLogs }
+async function call(txObj) {
+  const method = {
+    method: 'eth_call',
+    params: [txObj, 'latest'],
+  }
+  return send(method)
+}
+
+module.exports = { fetchBlock, fetchLatestBlock, getLogs, call }


### PR DESCRIPTION
- Added `IS_INSTANT` env variable, if it evaluates to true it toggles on all redux functionality associated with instant liquidity. If it is falsey (like it will be in the OTC app), all the extra instant functionality is turned off by default. This functionality includes: 
    - `CONNECT_WALLET` action also initiates a connection to the router
    - turning on polling of API values of users currently connected to the router, current intents, real-time balance & approval tracking of all makers

- Added the concept of `trackedAddresses` to `deltabalances`. A `trackedAddresses` is stored as an array of pairs `[{ tokenAddress, address },...]` where address is a wallet address. This list can be used by any dapp to add real time balance tracking of a wallet address and associated assets to the event blockCruncher. 

- Also added a `call` abstraction to `gethRead` to allow for websocket updates of deltabalance info (or any contract data read, just use the `Proxy`'d ethers JSON RPC provider as defined here: https://github.com/airswap/AirSwap.js/blob/sam-working/src/deltaBalances/index.js#L32. This now means that 100% of ethereum data fed into the app comes from `gethRead`, which can be configured to use any provider you want (nodesmith websocket, alchemy websocket, perhaps ipc provider)