### PR TITLE
poll for wallet web3 availability

### DIFF
--- a/src/wallet/redux/reducers.js
+++ b/src/wallet/redux/reducers.js
@@ -10,7 +10,7 @@ import {
   keyspaceDefaultSeedFn,
   keyspaceSignatureTextFn,
 } from '../../constants'
-import { walletTypes } from '../static/constants'
+import { web3WalletTypes } from '../static/constants'
 
 const defaultState = {
   connectingWallet: false,
@@ -71,7 +71,7 @@ function createWalletAvailable(walletType) {
   }
 }
 
-const walletAvailable = combineReducers(_.zipObject(walletTypes, walletTypes.map(createWalletAvailable)))
+const walletAvailable = combineReducers(_.zipObject(web3WalletTypes, web3WalletTypes.map(createWalletAvailable)))
 
 const walletState = combineReducers({
   connection: walletConnection,


### PR DESCRIPTION
Sometimes a web3 provider can inject their `window.web3` object later than expected, or a user can turn it on after the page loads. This PR helps with "liveness" of that state.