### PR TITLE
unsigned getOrderId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/src/utils/order.js
+++ b/src/utils/order.js
@@ -48,4 +48,10 @@ function getOrderId(order) {
   return `${makerAddress}${makerAmount}${makerToken}${takerAddress}${takerAmount}${takerToken}${expiration}${nonce}${r}${s}${v}`
 }
 
-module.exports = { isValidOrder, getOrderId }
+function getUnsignedOrderId(order) {
+  if (!_.isObject(order)) return false
+  const { makerAddress, makerAmount, makerToken, takerAddress, takerAmount, takerToken, expiration, nonce } = order
+  return `${makerAddress}${makerAmount}${makerToken}${takerAddress}${takerAmount}${takerToken}${expiration}${nonce}`
+}
+
+module.exports = { isValidOrder, getOrderId, getUnsignedOrderId }


### PR DESCRIPTION
I made a new function instead of overwriting the old one for backwards compatibility. maybe some clients have localstorage from the schema with the ECDSA signatures, and I don't want to harm them. So going forward I'll use the unsigned getOrderId function instead, but the old one will remain too