### PR TITLE
added app-based alchemy api keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/src/constants.js
+++ b/src/constants.js
@@ -128,12 +128,17 @@ const DELTA_BALANCES_CONTRACT_ADDRESS = (N => {
   }
 })(NETWORK)
 
+const ALECHEMY_RINKEBY_ID =
+  process.env.REACT_APP_ALECHEMY_RINKEBY_ID || process.env.ALECHEMY_RINKEBY_ID || 'SSm9sKBkb_vOyLjf5yXNGQ4QsBAeqm1S'
+const ALECHEMY_MAINNET_ID =
+  process.env.REACT_APP_ALECHEMY_MAINNET_ID || process.env.ALECHEMY_MAINNET_ID || '1e8iSwEIqstMQtW1133tjieia8pkQ4a8'
+
 const AIRSWAP_GETH_NODE_ADDRESS = (N => {
   switch (N) {
     case RINKEBY_ID:
-      return 'https://eth-rinkeby.alchemyapi.io/jsonrpc/SSm9sKBkb_vOyLjf5yXNGQ4QsBAeqm1S'
+      return `https://eth-rinkeby.alchemyapi.io/jsonrpc/${ALECHEMY_RINKEBY_ID}`
     case MAIN_ID:
-      return 'https://eth-mainnet.alchemyapi.io/jsonrpc/1e8iSwEIqstMQtW1133tjieia8pkQ4a8'
+      return `https://eth-mainnet.alchemyapi.io/jsonrpc/${ALECHEMY_MAINNET_ID}`
     default:
   }
 })(NETWORK)


### PR DESCRIPTION
This is a change at the alchemy team's suggestion. Using different keys for different applications allows their analytics to chart the load generated by our respective applications. In particular, I'm interested in using this for maker-stats, since that's the heaviest draw on the geth node currently. 