### PR TITLE
Only add gas price to ethTotal on buys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/src/protocolMessaging/redux/reducers.js
+++ b/src/protocolMessaging/redux/reducers.js
@@ -246,6 +246,7 @@ const getIsCurrentFrameFinishedQuerying = createSelector(
 
 const makeGetBestOrder = createSelector(
   getIsCurrentFrameFinishedQuerying,
+  getCurrentFrameQueryContext,
   gasSelectors.getCurrentGasPriceSettings,
   tokenSelectors.makeGetExchangeFillGasLimitByToken,
   fiatSelectors.makeGetEthInFiat,
@@ -260,6 +261,7 @@ const makeGetBestOrder = createSelector(
   getSwapAuthorizeTransactions,
   (
     isCurrentFrameFinishedQuerying,
+    currentFrameQueryContext,
     { gwei },
     getExchangeFillGasLimitByToken,
     getEthInFiat,
@@ -281,7 +283,11 @@ const makeGetBestOrder = createSelector(
     const ethGasPrice = Number(gwei) / 10 ** 9
     const ethGasLimit = Number(getExchangeFillGasLimitByToken({ symbol: bestOrder.tokenSymbol }))
     const ethGasCost = ethGasLimit * ethGasPrice
-    const ethTotal = bestOrder.ethAmount + ethGasCost
+    const { side } = currentFrameQueryContext
+    let ethTotal = bestOrder.ethAmount
+    if (side === 'sell') {
+      ethTotal += ethGasCost
+    }
     let missingApprovals
     if (bestOrder.swapVersion === 2) {
       const miningTakerTokenSwapApproval =


### PR DESCRIPTION
It doesn't make sense for the gas cost to be added to the `ethTotal` on sells, because in a sell the ETH is coming from the maker, and the taker is the one paying the gas cost.

<img width="617" alt="screen_shot_2019-09-09_at_1 47 11_pm" src="https://user-images.githubusercontent.com/13304874/64559184-b4a40c00-d313-11e9-8e0f-059c98688af1.png">
