### PR TITLE
abiGen refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint-staged": "lint-staged",
     "lint": "eslint src --ext .js,.jsx",
     "prettify": "prettier --write src/**/*.js",
-    "generate": "cd src && node generateReduxFromABI.js && yarn lint --fix"
+    "generate": "cd src && node abiGen.js && yarn lint --fix"
   },
   "pre-commit": [
     "lint-staged"

--- a/src/abiGen/generateContractFunctions.js
+++ b/src/abiGen/generateContractFunctions.js
@@ -1,0 +1,63 @@
+/* eslint-disable global-require */
+/* eslint-disable no-shadow */
+const _ = require('lodash')
+const { getContractFunctionName, getInterface } = require('./utils')
+
+function getInputNames(inputs) {
+  return _.map(inputs, ({ name, type }, i) => name || `${type}Input${i + 1}`)
+}
+
+function buildContractFunctionParams(inputs, type, payable, contractKey) {
+  const inputNames = getInputNames(inputs)
+  let parameters = inputNames
+  if (type === 'transaction') {
+    parameters.push('signer')
+  }
+  if (payable) {
+    parameters = ['ethAmount', ...parameters]
+  }
+
+  if (!contractKey) {
+    parameters = ['contractAddress', ...parameters]
+  }
+
+  return parameters
+}
+
+function generateContractFunctions(abiLocation, contractKey, eventNamespace = '') {
+  const abi = require(`../${abiLocation}`)
+  const contractFunctions = _.uniq(_.values(getInterface(abi).functions))
+  const functionArray = contractFunctions.map(({ inputs, payable, type, name }) => {
+    const parameters = buildContractFunctionParams(inputs, type, payable, contractKey)
+    const functionArgs = parameters.length ? `${parameters.join(', ')}` : ''
+    const getContract = type === 'transaction' ? 'signer' : 'constants.httpProvider'
+    const lastParamContractAddress = contractKey ? '' : ', contractAddress'
+    const functionName = getContractFunctionName(type, name, eventNamespace)
+    const inputNames = getInputNames(inputs)
+    const innerParamEthAmount = !payable
+      ? ''
+      : `${inputNames.length ? ', ' : ''}{ value: ethers.utils.bigNumberify(ethAmount || '0') }`
+    return `function ${functionName}(${functionArgs}) {
+  const contract = get${_.upperFirst(eventNamespace)}Contract(${getContract}${lastParamContractAddress})
+  return contract.${name}(${inputNames.join(', ')}${innerParamEthAmount})
+}
+`
+  })
+  const passedInContractAddress = contractKey ? '' : ', contractAddress'
+  const contractConstantsImport = "\nconst constants = require('../constants')\n"
+  const contractAddress = contractKey ? `constants.${contractKey}` : 'contractAddress'
+
+  return `const ethers = require('ethers')
+const abi = require('../${abiLocation}')${contractConstantsImport}
+function get${_.upperFirst(eventNamespace)}Contract(provider${passedInContractAddress}) {
+  return new ethers.Contract(${contractAddress}, abi, provider)
+}
+ ${functionArray.join('\n')}
+ 
+ module.exports = { ${contractFunctions.map(
+   ({ name, type }) => `${getContractFunctionName(type, name, eventNamespace)} `,
+ )} }
+`
+}
+
+module.exports = generateContractFunctions

--- a/src/abiGen/utils.js
+++ b/src/abiGen/utils.js
@@ -1,0 +1,23 @@
+const ethers = require('ethers')
+const _ = require('lodash')
+
+const getContractFunctionName = (type, name, eventNamespace) => {
+  const prefix = type === 'call' ? 'get' : 'submit'
+  if (_.upperFirst(eventNamespace) === _.upperFirst(name)) {
+    return `${prefix}${_.upperFirst(name)}`
+  }
+  return `${prefix}${_.upperFirst(eventNamespace)}${_.upperFirst(name)}`
+}
+
+const getContractFunctionActionType = (type, name, eventNamespace) =>
+  _.snakeCase(getContractFunctionName(type, name, eventNamespace)).toUpperCase()
+
+function getInterface(abi) {
+  return new ethers.utils.Interface(abi)
+}
+
+module.exports = {
+  getContractFunctionName,
+  getContractFunctionActionType,
+  getInterface,
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 const ethers = require('ethers')
 const _ = require('lodash')
+const { createAlchemyWeb3 } = require('@alch/alchemy-web3')
 const ERC20abi = require('human-standard-token-abi')
 const astAbi = require('./abis/AirSwapToken_rinkeby.json')
 const wethAbi = require('./abis/WETH_ABI.json')
@@ -88,7 +89,7 @@ const WRAPPER_CONTRACT_ADDRESS = (N => {
     case RINKEBY_ID:
       return '0x15fc598e31b98d73a7d56e10f079b827cb97af82'
     case MAIN_ID:
-      return '0x7d32b51258bbd675e47f55082ad3bb1133c5cc60'
+      return '0x5abcfbd462e175993c6c350023f8634d71daa61d'
     default:
   }
 })(NETWORK)
@@ -309,6 +310,8 @@ const IS_INSTANT = process.env.REACT_APP_INSTANT
 
 const INFINITE_EXPIRY = 253395176400 // 10/10/9999
 
+const alchemyWeb3 = createAlchemyWeb3(ALCHEMY_WEBSOCKET_URL)
+
 module.exports = {
   ENV,
   MAIN_ID,
@@ -366,4 +369,5 @@ module.exports = {
   WRAPPER_CONTRACT_ADDRESS,
   INFINITE_EXPIRY,
   ALCHEMY_WEBSOCKET_URL,
+  alchemyWeb3,
 }

--- a/src/deltaBalances/contractFunctions.js
+++ b/src/deltaBalances/contractFunctions.js
@@ -5,63 +5,77 @@ const constants = require('../constants')
 function getDeltaBalancesContract(provider) {
   return new ethers.Contract(constants.DELTA_BALANCES_CONTRACT_ADDRESS, abi, provider)
 }
-
-export function getDeltaBalancesAllBalancesForManyAccounts(users, tokens) {
+function getDeltaBalancesAllBalancesForManyAccounts(users, tokens) {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.allBalancesForManyAccounts(users, tokens)
 }
 
-export function getDeltaBalancesTokenBalance(user, token) {
+function getDeltaBalancesTokenBalance(user, token) {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.tokenBalance(user, token)
 }
 
-export function submitDeltaBalancesDestruct(signer) {
+function submitDeltaBalancesDestruct(signer) {
   const contract = getDeltaBalancesContract(signer)
   return contract.destruct()
 }
 
-export function getDeltaBalancesWalletAllowances(user, spender, tokens) {
+function getDeltaBalancesWalletAllowances(user, spender, tokens) {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.walletAllowances(user, spender, tokens)
 }
 
-export function submitDeltaBalancesWithdraw(signer) {
+function submitDeltaBalancesWithdraw(signer) {
   const contract = getDeltaBalancesContract(signer)
   return contract.withdraw()
 }
 
-export function getDeltaBalancesWalletBalances(user, tokens) {
+function getDeltaBalancesWalletBalances(user, tokens) {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.walletBalances(user, tokens)
 }
 
-export function getDeltaBalancesTokenAllowance(user, spender, token) {
+function getDeltaBalancesTokenAllowance(user, spender, token) {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.tokenAllowance(user, spender, token)
 }
 
-export function submitDeltaBalancesWithdrawToken(token, amount, signer) {
+function submitDeltaBalancesWithdrawToken(token, amount, signer) {
   const contract = getDeltaBalancesContract(signer)
   return contract.withdrawToken(token, amount)
 }
 
-export function getDeltaBalancesAllWETHbalances(wethAddress, users) {
+function getDeltaBalancesAllWETHbalances(wethAddress, users) {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.allWETHbalances(wethAddress, users)
 }
 
-export function getDeltaBalancesAllAllowancesForManyAccounts(users, spender, tokens) {
+function getDeltaBalancesAllAllowancesForManyAccounts(users, spender, tokens) {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.allAllowancesForManyAccounts(users, spender, tokens)
 }
 
-export function getDeltaBalancesAdmin() {
+function getDeltaBalancesAdmin() {
   const contract = getDeltaBalancesContract(constants.httpProvider)
   return contract.admin()
 }
 
-export function submitDeltaBalancesConstructor(_deployer, signer) {
+function submitDeltaBalancesConstructor(_deployer, signer) {
   const contract = getDeltaBalancesContract(signer)
   return contract.constructor(_deployer)
+}
+
+module.exports = {
+  getDeltaBalancesAllBalancesForManyAccounts,
+  getDeltaBalancesTokenBalance,
+  submitDeltaBalancesDestruct,
+  getDeltaBalancesWalletAllowances,
+  submitDeltaBalancesWithdraw,
+  getDeltaBalancesWalletBalances,
+  getDeltaBalancesTokenAllowance,
+  submitDeltaBalancesWithdrawToken,
+  getDeltaBalancesAllWETHbalances,
+  getDeltaBalancesAllAllowancesForManyAccounts,
+  getDeltaBalancesAdmin,
+  submitDeltaBalancesConstructor,
 }

--- a/src/erc20/contractFunctions.js
+++ b/src/erc20/contractFunctions.js
@@ -5,58 +5,71 @@ const constants = require('../constants')
 function getERC20Contract(provider, contractAddress) {
   return new ethers.Contract(contractAddress, abi, provider)
 }
-
-export function getERC20Name(contractAddress) {
+function getERC20Name(contractAddress) {
   const contract = getERC20Contract(constants.httpProvider, contractAddress)
   return contract.name()
 }
 
-export function submitERC20Approve(contractAddress, spender, value, signer) {
+function submitERC20Approve(contractAddress, spender, value, signer) {
   const contract = getERC20Contract(signer, contractAddress)
   return contract.approve(spender, value)
 }
 
-export function getERC20TotalSupply(contractAddress) {
+function getERC20TotalSupply(contractAddress) {
   const contract = getERC20Contract(constants.httpProvider, contractAddress)
   return contract.totalSupply()
 }
 
-export function submitERC20TransferFrom(contractAddress, from, to, value, signer) {
+function submitERC20TransferFrom(contractAddress, from, to, value, signer) {
   const contract = getERC20Contract(signer, contractAddress)
   return contract.transferFrom(from, to, value)
 }
 
-export function getERC20Decimals(contractAddress) {
+function getERC20Decimals(contractAddress) {
   const contract = getERC20Contract(constants.httpProvider, contractAddress)
   return contract.decimals()
 }
 
-export function getERC20Version(contractAddress) {
+function getERC20Version(contractAddress) {
   const contract = getERC20Contract(constants.httpProvider, contractAddress)
   return contract.version()
 }
 
-export function getERC20BalanceOf(contractAddress, owner) {
+function getERC20BalanceOf(contractAddress, owner) {
   const contract = getERC20Contract(constants.httpProvider, contractAddress)
   return contract.balanceOf(owner)
 }
 
-export function getERC20Symbol(contractAddress) {
+function getERC20Symbol(contractAddress) {
   const contract = getERC20Contract(constants.httpProvider, contractAddress)
   return contract.symbol()
 }
 
-export function submitERC20Transfer(contractAddress, to, value, signer) {
+function submitERC20Transfer(contractAddress, to, value, signer) {
   const contract = getERC20Contract(signer, contractAddress)
   return contract.transfer(to, value)
 }
 
-export function submitERC20ApproveAndCall(contractAddress, spender, value, extraData, signer) {
+function submitERC20ApproveAndCall(contractAddress, spender, value, extraData, signer) {
   const contract = getERC20Contract(signer, contractAddress)
   return contract.approveAndCall(spender, value, extraData)
 }
 
-export function getERC20Allowance(contractAddress, owner, spender) {
+function getERC20Allowance(contractAddress, owner, spender) {
   const contract = getERC20Contract(constants.httpProvider, contractAddress)
   return contract.allowance(owner, spender)
+}
+
+module.exports = {
+  getERC20Name,
+  submitERC20Approve,
+  getERC20TotalSupply,
+  submitERC20TransferFrom,
+  getERC20Decimals,
+  getERC20Version,
+  getERC20BalanceOf,
+  getERC20Symbol,
+  submitERC20Transfer,
+  submitERC20ApproveAndCall,
+  getERC20Allowance,
 }

--- a/src/events/redux/middleware.js
+++ b/src/events/redux/middleware.js
@@ -9,7 +9,7 @@ import { getEventId } from '../utils'
 import * as gethRead from '../../utils/gethRead'
 import { buildGlobalERC20TransfersTopics, fetchLogs } from '../index'
 import { gotBlocks } from '../../blockTracker/redux/actions'
-import eventTracker from '../eventTracker'
+import eventTracker from '../websocketEventTracker'
 import { trackSwapSwap, trackSwapCancel } from '../../swap/redux/eventTrackingActions'
 import {
   trackSwapLegacyCanceled,

--- a/src/events/utils.js
+++ b/src/events/utils.js
@@ -1,5 +1,44 @@
+const ethers = require('ethers')
+const _ = require('lodash')
+
 function getEventId({ transactionHash, logIndex }) {
   return `${transactionHash}-${logIndex}`
 }
 
-module.exports = { getEventId }
+function parseEventLog(log, abiInterface) {
+  let parsedLog
+  try {
+    parsedLog = abiInterface.parseLog(log)
+  } catch (e) {
+    // this was added because ERC721 transactions show up under the Transfer topic but can't be parsed by the human-standard-token abi
+    return null
+  }
+  console.log('parsedLog', parsedLog, log.address)
+  if (!parsedLog) {
+    return null
+  }
+  const parsedLogValues = _.mapValues(parsedLog.values, v => ((v.toString ? v.toString() : v) || '').toLowerCase()) // converts bignumbers to strings and lowercases everything (most importantly addresses)
+  const argumentRange = _.range(Number(parsedLogValues.length)).map(p => p.toString())
+  const formattedLogValues = _.pickBy(
+    parsedLogValues,
+    (param, key) => !_.includes(argumentRange, key) && key !== 'length', // removes some extra junk ethers puts in the parsed logs
+  )
+  const { address, topics, data, blockNumber, transactionHash, removed, transactionIndex, logIndex } = log
+  const { name, signature, topic } = parsedLog
+  return {
+    ...{
+      address,
+      topics,
+      data,
+      blockNumber: ethers.utils.bigNumberify(blockNumber).toNumber(),
+      transactionIndex: ethers.utils.bigNumberify(transactionIndex).toNumber(),
+      logIndex: ethers.utils.bigNumberify(logIndex).toNumber(),
+      transactionHash,
+      removed,
+    },
+    ...{ name, signature, topic },
+    values: formattedLogValues,
+  }
+}
+
+module.exports = { getEventId, parseEventLog }

--- a/src/events/utils.js
+++ b/src/events/utils.js
@@ -13,7 +13,7 @@ function parseEventLog(log, abiInterface) {
     // this was added because ERC721 transactions show up under the Transfer topic but can't be parsed by the human-standard-token abi
     return null
   }
-  console.log('parsedLog', parsedLog, log.address)
+
   if (!parsedLog) {
     return null
   }

--- a/src/events/websocketEventTracker.js
+++ b/src/events/websocketEventTracker.js
@@ -1,0 +1,92 @@
+const _ = require('lodash')
+const ethers = require('ethers')
+const blockTracker = require('../blockTracker')
+const { alchemyWeb3 } = require('../constants')
+const { parseEventLog } = require('./utils')
+
+const { Interface } = ethers.utils
+
+async function subscribe(contractAddress, abi, topic, fromBlock, callback, parser) {
+  const query = {
+    address: contractAddress || undefined,
+    topics: topic,
+  }
+
+  const logParams = {
+    ...query,
+    fromBlock,
+  }
+
+  const abiInterface = new Interface(abi)
+  const subscription = alchemyWeb3.eth.subscribe('logs', logParams, (error, log) => {
+    if (parser) {
+      callback(parser(parseEventLog(log, abiInterface)))
+    } else {
+      const parsedEventLog = parseEventLog(log, abiInterface)
+      callback([parsedEventLog])
+    }
+  })
+
+  return subscription
+}
+
+class EventTracker {
+  constructor() {
+    this.trackedEvents = []
+  }
+  async trackEvent(event) {
+    await blockTracker.readyPromise
+    const latestBlockNumber = blockTracker.getLatestBlockNumber()
+    this.subscribeToEvent(event, latestBlockNumber)
+    this.trackedEvents.push(event)
+  }
+  subscribeToEvent(event, blockNumber) {
+    //eslint-disable-line
+    const { contract, abi, callback, parser, backFillBlockCount, fromBlock } = event
+    let fromBlockNumberOverride
+    if (!_.isUndefined(fromBlock)) {
+      fromBlockNumberOverride = Number(fromBlock)
+    } else if (!_.isUndefined(backFillBlockCount)) {
+      fromBlockNumberOverride = blockNumber - Number(backFillBlockCount)
+    } else {
+      fromBlockNumberOverride = blockNumber
+    }
+    const topics = this.getEventTopics(event)
+    subscribe(contract, abi, topics, fromBlockNumberOverride, callback, parser)
+  }
+  // eslint-disable-next-line
+  getEventTopics({ name, params: paramsInputs, abi }) {
+    const params = paramsInputs || {} // default to empty object if undefined
+    const abiInterface = new ethers.utils.Interface(abi)
+    const { events } = abiInterface
+    const abiEvent = events[name]
+    if (!abiEvent) {
+      throw new Error(
+        `${name} not an abi event, possible events are ${_.uniq(_.map(_.values(events), 'name')).join(', ')}`,
+      )
+    }
+    const paramsArray = abiEvent.inputs.map(
+      ({ name: inputName }) => (_.isUndefined(params[inputName]) ? null : params[inputName]),
+    )
+    return abiEvent.encodeTopics(paramsArray)
+  }
+}
+
+const eventTracker = new EventTracker()
+
+// USAGE
+/*
+eventTracker.trackEvent({
+  contract: SWAP_LEGACY_CONTRACT_ADDRESS, // optional, the contract that emitted the event. If left out, all events matching that signature will be tracked (for all contracts).
+  name: 'Filled', // required, the name of the event emitted by the contract
+  params: {
+    // optional, indexed params emitted by the contract
+    takerToken: '0xdead0717b16b9f56eb6e308e4b29230dc0eee0b6',
+  },
+  abi: abis[SWAP_LEGACY_CONTRACT_ADDRESS], // required, abi of the contract
+  callback: logs => console.log(logs),
+  backFillBlockCount: 7000, // optional, if included, first callback execution will include that many blocks BEFORE the current block
+})
+*/
+
+module.exports = eventTracker

--- a/src/swap/contractFunctions.js
+++ b/src/swap/contractFunctions.js
@@ -5,43 +5,53 @@ const constants = require('../constants')
 function getSwapContract(provider) {
   return new ethers.Contract(constants.SWAP_CONTRACT_ADDRESS, abi, provider)
 }
-
-export function getSwapMakerMinimumNonce(makerWallet) {
+function getSwapMakerMinimumNonce(makerWallet) {
   const contract = getSwapContract(constants.httpProvider)
   return contract.makerMinimumNonce(makerWallet)
 }
 
-export function getSwapMakerOrderStatus(makerWallet, nonce) {
+function getSwapMakerOrderStatus(makerWallet, nonce) {
   const contract = getSwapContract(constants.httpProvider)
   return contract.makerOrderStatus(makerWallet, nonce)
 }
 
-export function getSwapDelegateApprovals(approver, delegate) {
+function getSwapDelegateApprovals(approver, delegate) {
   const contract = getSwapContract(constants.httpProvider)
   return contract.delegateApprovals(approver, delegate)
 }
 
-export function submitSwap(order, signer) {
+function submitSwap(order, signer) {
   const contract = getSwapContract(signer)
   return contract.swap(order)
 }
 
-export function submitSwapCancel(nonces, signer) {
+function submitSwapCancel(nonces, signer) {
   const contract = getSwapContract(signer)
   return contract.cancel(nonces)
 }
 
-export function submitSwapInvalidate(minimumNonce, signer) {
+function submitSwapInvalidate(minimumNonce, signer) {
   const contract = getSwapContract(signer)
   return contract.invalidate(minimumNonce)
 }
 
-export function submitSwapAuthorize(delegate, expiry, signer) {
+function submitSwapAuthorize(delegate, expiry, signer) {
   const contract = getSwapContract(signer)
   return contract.authorize(delegate, expiry)
 }
 
-export function submitSwapRevoke(delegate, signer) {
+function submitSwapRevoke(delegate, signer) {
   const contract = getSwapContract(signer)
   return contract.revoke(delegate)
+}
+
+module.exports = {
+  getSwapMakerMinimumNonce,
+  getSwapMakerOrderStatus,
+  getSwapDelegateApprovals,
+  submitSwap,
+  submitSwapCancel,
+  submitSwapInvalidate,
+  submitSwapAuthorize,
+  submitSwapRevoke,
 }

--- a/src/utils/gethRead.js
+++ b/src/utils/gethRead.js
@@ -1,17 +1,14 @@
-const { createAlchemyWeb3 } = require('@alch/alchemy-web3')
 const _ = require('lodash')
 const ethers = require('ethers')
 const uuid = require('uuid')
 const WebSocket = require('isomorphic-ws')
 const { formatErrorMessage } = require('../utils/transformations')
-const { NODESMITH_URL, NODESMITH_KEY, ALCHEMY_WEBSOCKET_URL } = require('../constants')
+const { NODESMITH_URL, NODESMITH_KEY, alchemyWeb3 } = require('../constants')
 
 const nodesmithSupported = !!NODESMITH_KEY
 const callbacks = {}
 let nodesmithProvider
 let nodesmithOpenPromise
-
-const alchemyWeb3 = createAlchemyWeb3(ALCHEMY_WEBSOCKET_URL)
 
 async function initializeNodesmith() {
   nodesmithProvider = new WebSocket(NODESMITH_URL)
@@ -137,4 +134,12 @@ async function call(txObj, blockTag = 'latest') {
   return send(method)
 }
 
-module.exports = { fetchBlock, fetchLatestBlock, getLogs, call, fetchPendingBlock, fetchCurrentBlockNumber }
+module.exports = {
+  fetchBlock,
+  fetchLatestBlock,
+  getLogs,
+  call,
+  fetchPendingBlock,
+  fetchCurrentBlockNumber,
+  alchemyWeb3,
+}

--- a/src/utils/transformations.js
+++ b/src/utils/transformations.js
@@ -1,5 +1,5 @@
 const { ethers } = require('ethers')
-const { abis, SWAP_CONTRACT_ADDRESS } = require('../constants')
+const { abis, SWAP_CONTRACT_ADDRESS, WRAPPER_CONTRACT_ADDRESS } = require('../constants')
 
 const _ = require('lodash')
 const BigNumber = require('bignumber.js')
@@ -103,7 +103,8 @@ function getParsedInputFromTransaction(transaction) {
 
   return {
     name,
-    parameters: to === SWAP_CONTRACT_ADDRESS ? parseSwapParameters(parameters) : parameters,
+    parameters:
+      to === SWAP_CONTRACT_ADDRESS || to === WRAPPER_CONTRACT_ADDRESS ? parseSwapParameters(parameters) : parameters,
     formattedETHValue: value,
   }
 }

--- a/src/weth/contractFunctions.js
+++ b/src/weth/contractFunctions.js
@@ -5,58 +5,71 @@ const constants = require('../constants')
 function getWethContract(provider) {
   return new ethers.Contract(constants.WETH_CONTRACT_ADDRESS, abi, provider)
 }
-
-export function getWethName() {
+function getWethName() {
   const contract = getWethContract(constants.httpProvider)
   return contract.name()
 }
 
-export function submitWethApprove(spender, amount, signer) {
+function submitWethApprove(spender, amount, signer) {
   const contract = getWethContract(signer)
   return contract.approve(spender, amount)
 }
 
-export function getWethTotalSupply() {
+function getWethTotalSupply() {
   const contract = getWethContract(constants.httpProvider)
   return contract.totalSupply()
 }
 
-export function submitWethTransferFrom(from, to, amount, signer) {
+function submitWethTransferFrom(from, to, amount, signer) {
   const contract = getWethContract(signer)
   return contract.transferFrom(from, to, amount)
 }
 
-export function submitWethWithdraw(amount, signer) {
+function submitWethWithdraw(amount, signer) {
   const contract = getWethContract(signer)
   return contract.withdraw(amount)
 }
 
-export function getWethDecimals() {
+function getWethDecimals() {
   const contract = getWethContract(constants.httpProvider)
   return contract.decimals()
 }
 
-export function getWethBalanceOf(owner) {
+function getWethBalanceOf(owner) {
   const contract = getWethContract(constants.httpProvider)
   return contract.balanceOf(owner)
 }
 
-export function getWethSymbol() {
+function getWethSymbol() {
   const contract = getWethContract(constants.httpProvider)
   return contract.symbol()
 }
 
-export function submitWethTransfer(to, amount, signer) {
+function submitWethTransfer(to, amount, signer) {
   const contract = getWethContract(signer)
   return contract.transfer(to, amount)
 }
 
-export function submitWethDeposit(ethAmount, signer) {
+function submitWethDeposit(ethAmount, signer) {
   const contract = getWethContract(signer)
   return contract.deposit({ value: ethers.utils.bigNumberify(ethAmount || '0') })
 }
 
-export function getWethAllowance(owner, spender) {
+function getWethAllowance(owner, spender) {
   const contract = getWethContract(constants.httpProvider)
   return contract.allowance(owner, spender)
+}
+
+module.exports = {
+  getWethName,
+  submitWethApprove,
+  getWethTotalSupply,
+  submitWethTransferFrom,
+  submitWethWithdraw,
+  getWethDecimals,
+  getWethBalanceOf,
+  getWethSymbol,
+  submitWethTransfer,
+  submitWethDeposit,
+  getWethAllowance,
 }

--- a/src/wrapper/contractFunctions.js
+++ b/src/wrapper/contractFunctions.js
@@ -5,18 +5,19 @@ const constants = require('../constants')
 function getWrapperContract(provider) {
   return new ethers.Contract(constants.WRAPPER_CONTRACT_ADDRESS, abi, provider)
 }
-
-export function getWrapperWethContract() {
+function getWrapperWethContract() {
   const contract = getWrapperContract(constants.httpProvider)
   return contract.wethContract()
 }
 
-export function getWrapperSwapContract() {
+function getWrapperSwapContract() {
   const contract = getWrapperContract(constants.httpProvider)
   return contract.swapContract()
 }
 
-export function submitWrapperSwap(ethAmount, order, signer) {
+function submitWrapperSwap(ethAmount, order, signer) {
   const contract = getWrapperContract(signer)
   return contract.swap(order, { value: ethers.utils.bigNumberify(ethAmount || '0') })
 }
+
+module.exports = { getWrapperWethContract, getWrapperSwapContract, submitWrapperSwap }


### PR DESCRIPTION
- moved `generateContractFunctions` into an `/abiGen` submodule. Moved `abiGen` utils into a `/abiGen/utils.js` submodule. Trying to get away from the large flat file that is currently the abiGeneration code into something more maintainable / documentable.
- changed `generateContractFunctions` generated files to use pure commonjs exports. Mixed module declarations were causing issues when trying to include these functions in nodejs code (makers)
 - introduced a `alchemyWeb3` event subscription module `websocketEventTracker`. The fallback http event tracking module `eventTracker` will still be available. I don't want the codebase to become dependent on websocket subscriptions. Http will be available as a fallback, even if it's slow. 
- updated to the latest wrapper contract address. 