### PR TITLE
key ui selectors by symbol and address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/src/tokens/redux/reducers.js
+++ b/src/tokens/redux/reducers.js
@@ -62,7 +62,9 @@ const areTokensReady = state => state.tokens.ready
 const getTokenAddresses = createSelector(getTokens, t => _.map(t, 'address'))
 const getTokenBySymbol = (state, symbol) => _.find(getTokens(state), { symbol })
 const getTokensBySymbol = createSelector(getTokens, t => _.keyBy(t, 'symbol'))
+const getAirSwapApprovedTokensBySymbol = createSelector(getAirSwapApprovedTokens, t => _.keyBy(t, 'symbol'))
 const getTokensByAddress = createSelector(getTokens, t => _.keyBy(t, 'address'))
+const getAirSwapApprovedTokensByAddress = createSelector(getAirSwapApprovedTokens, t => _.keyBy(t, 'address'))
 const getTokensSymbols = createSelector(getTokens, t => _.map(t, 'symbol'))
 const getTokensSymbolsByAddress = createSelector(getTokensByAddress, tokensByAddress =>
   _.mapValues(tokensByAddress, t => t.symbol),
@@ -244,6 +246,8 @@ export const selectors = {
   getBaseTokens,
   makeGetReadableOrder,
   getAirSwapApprovedTokens,
+  getAirSwapApprovedTokensBySymbol,
+  getAirSwapApprovedTokensByAddress,
   makeParseByToken,
   makeGetExchangeFillGasLimitByToken,
   makeGetReadableSwapOrder,


### PR DESCRIPTION
`getTokensByAddress` and `getTokensBySymbol` are often used in UI code, but really it's pretty rare that the UI should be looking at the entire metadata set. Most of the time it should be using "airswap approved" tokens for display in the UI.