### PR TITLE
Fixes for delegates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam .walker@fluidity.io>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam .walker@fluidity.io>",

--- a/src/callData/redux/middleware.js
+++ b/src/callData/redux/middleware.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { fetchSwapSenderAuthorizations } from '../../swap/redux/contractFunctionActions'
 import { fetchERC20Allowance } from '../../erc20/redux/contractFunctionActions'
 import { fetchERC721GetApprovedOverride } from '../../erc721/redux/actions'
+import { getTokenAllowancesForConnectedAddress } from '../../deltaBalances/redux/actions'
 
 export default function callData(store) {
   return next => action => {
@@ -38,6 +39,8 @@ export default function callData(store) {
                 spender: parsedEventValues.spender.toLowerCase(),
               }),
             )
+            // put approvals in deltaBalances as well
+            store.dispatch(getTokenAllowancesForConnectedAddress([event.address.toLowerCase()]))
           }
         }
         break

--- a/src/delegate/redux/selectors.js
+++ b/src/delegate/redux/selectors.js
@@ -106,9 +106,23 @@ const getFormattedDelegateRules = createSelector(
           '0',
         )
 
+        const providedOrdersSignerSum = _.reduce(
+          providedOrdersForRule,
+          (sum, order) =>
+            bn(sum)
+              .add(order.signerAmount)
+              .toString(),
+          '0',
+        )
+
         const providedOrdersSenderSumDisplayValue = `${displayByToken(
           { address: senderToken },
           providedOrdersSenderSum,
+        )}`
+
+        const providedOrdersSignerSumDisplayValue = `${displayByToken(
+          { address: signerToken },
+          providedOrdersSignerSum,
         )}`
 
         const {
@@ -140,6 +154,7 @@ const getFormattedDelegateRules = createSelector(
           senderToken,
           signerToken,
           providedOrdersSenderSumDisplayValue,
+          providedOrdersSignerSumDisplayValue,
           fillRatio,
           senderSymbol: tokensSymbolsByAddress[senderToken],
           signerSymbol: tokensSymbolsByAddress[signerToken],

--- a/src/deltaBalances/redux/actions.js
+++ b/src/deltaBalances/redux/actions.js
@@ -13,9 +13,9 @@ export const getAllAllowancesForConnectedAddress = address => ({
   address,
 })
 
-export const getTokenAllowancesForConnectedAddress = address => ({
+export const getTokenAllowancesForConnectedAddress = tokens => ({
   type: 'GET_TOKEN_ALLOWANCES_FOR_CONNECTED_ADDRESS',
-  address,
+  tokens,
 })
 
 export const addTrackedAddress = ({ address, tokenAddress }) => ({


### PR DESCRIPTION
 - fixed an issue where deltaBalances approvals weren't reloading after an approval. Currently approvals are stored in two places, abiGen erc20 reducers and deltaBalances reducers. Eventually deltaBalances will be deprecated, for now, I'll store approval results in both places to not cause issues in the meantime. 
 - added `providedOrdersSignerSumDisplayValue` to formatted delegate rule selector