### PR TITLE
Token caching

### DIFF
--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -31,7 +31,7 @@ export default function configureStore(
   persistedState = [],
 ) {
   let engine = createEngine(storageKey)
-  engine = filter(engine, [['wallet', 'expressLogin'], ['tokens', 'data'], ...persistedState])
+  engine = filter(engine, [['wallet', 'expressLogin'], ...persistedState], ['tokens', 'data'])
   const persistMiddleware = storage.createMiddleware(engine, actionsBlacklist)
   const rootReducer = combineReducers(_.pickBy({ ...projectRootReducerObj, ...rootReducerObj }, _.identity))
   const reducer = storage.reducer(rootReducer)

--- a/src/tokens/index.js
+++ b/src/tokens/index.js
@@ -90,30 +90,6 @@ function mapToOldMetadataSchema(metadata) {
   }
 }
 
-function getDefaultTokens() {
-  // @airswap/metadata doesn't include ETH since it isn't a token
-  let tokens = [
-    {
-      airswapUI: 'yes',
-      colors: ['#343434', '#7f7f7c', '#8c8c8c', '#939493', '#d4d6d4'],
-      symbol: 'ETH',
-      decimals: '18',
-      address: '0x0000000000000000000000000000000000000000',
-      airswap_img_url: 'https://s3.amazonaws.com/airswap-token-images/ETH.png',
-    },
-  ]
-  // persistent cache for the frontend only
-  if (typeof window !== 'undefined' && window.localStorage) {
-    try {
-      tokens = _.get(JSON.parse(window.localStorage['@airswapjs'] || '{}'), 'tokens.data', tokens)
-    } catch (e) {
-      console.log(e)
-    }
-  }
-
-  return tokens
-}
-
 class OldTokenMetadata {
   constructor() {
     const metadataPkg = new TokenMetadata(NETWORK)
@@ -123,7 +99,6 @@ class OldTokenMetadata {
       return this.tokens
     })
 
-    this.tokens = getDefaultTokens()
     this.nftItems = []
     this.metadataPkg = metadataPkg
   }


### PR DESCRIPTION
Adds `['tokens', 'data']` to localStorage blacklist and always uses fresh AirSwap token metadata on load.