### PR TITLE
Fixes connection issue in Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.190",
+  "version": "0.1.191",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.191",
+  "version": "0.1.192",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "author": "Sam Walker <sam.walker@fluidity.io>",

--- a/src/tokens/index.js
+++ b/src/tokens/index.js
@@ -103,7 +103,7 @@ class OldTokenMetadata {
     this.metadataPkg = metadataPkg
   }
   setTokens(tokens) {
-    this.tokens = _.uniqBy([...this.tokens, ...tokens], 'address')
+    this.tokens = _.uniqBy([...(this.tokens || []), ...tokens], 'address')
     this.airswapUITokens = _.filter(tokens, { airswapUI: 'yes' })
     this.tokensByAddress = _.keyBy(tokens, 'address')
     this.tokenSymbolsByAddress = _.mapValues(this.tokensByAddress, t => t.symbol)

--- a/src/utils/retryProvider.js
+++ b/src/utils/retryProvider.js
@@ -1,27 +1,36 @@
 const { JsonRpcProvider } = require('ethers/providers')
 const { poll } = require('ethers/utils/web')
+const axios = require('axios')
 
-const ATTEMPTS = 5
+const MAX_ATTEMPTS = 5
 
 class RetryProvider extends JsonRpcProvider {
   constructor(url, network) {
     super(url, network)
-    this.attempts = ATTEMPTS
+    this.url = url
+    this.id = 1
   }
 
-  perform(method, params) {
+  send(method, params) {
     let attempts = 0
     return poll(() => {
       attempts++
-      return super.perform(method, params).then(
-        result => result,
-        error => {
-          if ((error.statusCode !== 0 && error.statusCode !== 429) || attempts >= this.attempts) {
-            return Promise.reject(error)
-          }
-          return Promise.resolve(undefined)
-        },
-      )
+      return axios
+        .post(this.url, {
+          method,
+          params,
+          id: this.id++,
+          jsonrpc: '2.0',
+        })
+        .then(
+          response => Promise.resolve(response.data.result),
+          response => {
+            if ((response.statusCode !== 0 && response.statusCode !== 429) || attempts >= MAX_ATTEMPTS) {
+              return Promise.reject(response)
+            }
+            return Promise.resolve(undefined)
+          },
+        )
     })
   }
 }


### PR DESCRIPTION
Underlying connection in ethers `JsonRpcProvider` had been consistently failing. It appeared that the HTTP version was being incorrectly set. Instead of `POST ... HTTP/2` the request would read `POST ... undefined`. Overriding the send function and using axios fixes the issue. If there's something lighter weight happy to check it out. Tested in Firefox and Chrome.

Also added a null check in `setTokens` in `src/tokens/index.js`.