### PR TITLE
Expect ethereum node URLs to be passed or use provider defaults

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
     "no-plusplus": "off",
     "no-case-declarations": "off",
     "no-continue": "off",
+    "no-new": "off",
     "new-cap": "off",
     "import/no-named-as-default": "off",
     "react/require-default-props": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airswap.js",
-  "version": "0.1.193",
+  "version": "0.2.0",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "airswap.js",
-  "version": "0.1.192",
+  "version": "0.1.193",
   "description": "JavaScript Modules for AirSwap Developers",
   "repository": "https://github.com/airswap/AirSwap.js",
-  "author": "Sam Walker <sam.walker@fluidity.io>",
+  "contributors": [
+    "Sam Walker <sam.walker@fluidity.io>",
+    "Don Mosites <don.mosites@fluidity.io>"
+  ],
   "license": "Apache-2.0",
   "devDependencies": {
     "@airswap/delegate": "^2.6.9",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@airswap/constants": "^0.3.9",
-    "@airswap/metadata": "^0.1.11",
+    "@airswap/metadata": "^0.2.0",
     "@airswap/order-utils": "^0.3.20",
     "@portis/web3": "^2.0.0-beta.16",
     "axios": "^0.18.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -86,7 +86,7 @@ const NETWORK_NAME = NAME_MAPPING[NETWORK]
 let ETH_NODE_HTTP
 let ethersProvider = ethers.getDefaultProvider(NETWORK)
 
-// If set, expects URL in the form e.g. https://{NETWORK}.infura.io/v3/...
+// If set, expects a URL e.g. "https://{NETWORK}.infura.io/v3/..."
 if (process.env.ETH_NODE_HTTP || process.env.REACT_APP_ETH_NODE_HTTP) {
   let node_url = process.env.ETH_NODE_HTTP
   if (process.env.REACT_APP_ETH_NODE_HTTP) {
@@ -107,6 +107,7 @@ if (process.env.ETH_NODE_HTTP || process.env.REACT_APP_ETH_NODE_HTTP) {
 let ETH_NODE_WEBSOCKET
 let web3Provider = new Web3(Web3.givenProvider)
 
+// If set, expects a URL e.g. "wss://{NETWORK}.infura.io/ws/v3/..."
 if (process.env.ETH_NODE_WEBSOCKET || process.env.REACT_APP_ETH_NODE_WEBSOCKET) {
   let node_url = process.env.ETH_NODE_WEBSOCKET
   if (process.env.REACT_APP_ETH_NODE_WEBSOCKET) {
@@ -123,7 +124,6 @@ if (process.env.ETH_NODE_WEBSOCKET || process.env.REACT_APP_ETH_NODE_WEBSOCKET) 
   ETH_NODE_WEBSOCKET = node_url
   web3Provider = new Web3(
     new Web3.providers.WebsocketProvider(node_url, {
-      // Enable auto reconnection
       reconnect: {
         auto: true,
         delay: 5000, // ms
@@ -132,14 +132,11 @@ if (process.env.ETH_NODE_WEBSOCKET || process.env.REACT_APP_ETH_NODE_WEBSOCKET) 
       },
     }),
   )
-  // this doesn't appear to work for some reason, will investigate another time
-  // call to deltabalances contracts were never sent in the websocket when I tried to use the web3 websocket as the provider for ethers
-  // no errors were thrown, the calls just never showed up in the network tab even though the functions were being called
-  // const ethersProvider = new ethers.providers.Web3Provider(web3Provider.currentProvider)
 }
 
 if (process.env.MOCHA_IS_TESTING || process.env.REACT_APP_TESTING) {
   ethersProvider = new RetryProvider('http://localhost:8545', NETWORK)
+  web3Provider = new Web3('http://localhost:8545')
 }
 
 const SWAP_CONTRACT_ADDRESS = contractConstants.swap[String(NETWORK)]

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 require('dotenv').config({ path: `${__dirname}/../.env` })
 const _ = require('lodash')
+const ethers = require('ethers')
 const Web3 = require('web3')
 const queryString = require('querystring')
 const ERC20abi = require('human-standard-token-abi')
@@ -39,6 +40,7 @@ const NETWORK_MAPPING = {
 }
 
 const NAME_MAPPING = {
+  [MAIN_ID]: 'mainnet',
   [RINKEBY_ID]: 'rinkeby',
   [KOVAN_ID]: 'kovan',
   [GOERLI_ID]: 'goerli',
@@ -80,6 +82,65 @@ if (typeof window !== 'undefined') {
 }
 
 const NETWORK_NAME = NAME_MAPPING[NETWORK]
+
+let ETH_NODE_HTTP
+let ethersProvider = ethers.getDefaultProvider(NETWORK)
+
+// If set, expects URL in the form e.g. https://{NETWORK}.infura.io/v3/...
+if (process.env.ETH_NODE_HTTP || process.env.REACT_APP_ETH_NODE_HTTP) {
+  let node_url = process.env.ETH_NODE_HTTP
+  if (process.env.REACT_APP_ETH_NODE_HTTP) {
+    node_url = process.env.REACT_APP_ETH_NODE_HTTP
+  }
+  node_url = node_url.replace(/{NETWORK}/g, NETWORK_NAME)
+
+  try {
+    new URL(node_url)
+  } catch (e) {
+    throw new Error('Invalid HTTP URL for Ethereum node (ETH_NODE_HTTP)')
+  }
+
+  ETH_NODE_HTTP = node_url
+  ethersProvider = new RetryProvider(node_url, NETWORK)
+}
+
+let ETH_NODE_WEBSOCKET
+let web3Provider = new Web3(Web3.givenProvider)
+
+if (process.env.ETH_NODE_WEBSOCKET || process.env.REACT_APP_ETH_NODE_WEBSOCKET) {
+  let node_url = process.env.ETH_NODE_WEBSOCKET
+  if (process.env.REACT_APP_ETH_NODE_WEBSOCKET) {
+    node_url = process.env.REACT_APP_ETH_NODE_WEBSOCKET
+  }
+  node_url = node_url.replace(/{NETWORK}/g, NETWORK_NAME)
+
+  try {
+    new URL(node_url)
+  } catch (e) {
+    throw new Error('Invalid Websocket URL for Ethereum node (ETH_NODE_WEBSOCKET)')
+  }
+
+  ETH_NODE_WEBSOCKET = node_url
+  web3Provider = new Web3(
+    new Web3.providers.WebsocketProvider(node_url, {
+      // Enable auto reconnection
+      reconnect: {
+        auto: true,
+        delay: 5000, // ms
+        maxAttempts: 100,
+        onTimeout: false,
+      },
+    }),
+  )
+  // this doesn't appear to work for some reason, will investigate another time
+  // call to deltabalances contracts were never sent in the websocket when I tried to use the web3 websocket as the provider for ethers
+  // no errors were thrown, the calls just never showed up in the network tab even though the functions were being called
+  // const ethersProvider = new ethers.providers.Web3Provider(web3Provider.currentProvider)
+}
+
+if (process.env.MOCHA_IS_TESTING || process.env.REACT_APP_TESTING) {
+  ethersProvider = new RetryProvider('http://localhost:8545', NETWORK)
+}
 
 const SWAP_CONTRACT_ADDRESS = contractConstants.swap[String(NETWORK)]
 
@@ -230,131 +291,6 @@ const DELTA_BALANCES_CONTRACT_ADDRESS = (N => {
     default:
   }
 })(NETWORK)
-
-const ALCHEMY_RINKEBY_ID = process.env.REACT_APP_ALCHEMY_RINKEBY_ID || process.env.ALCHEMY_RINKEBY_ID
-const ALCHEMY_MAINNET_ID = process.env.REACT_APP_ALCHEMY_MAINNET_ID || process.env.ALCHEMY_MAINNET_ID
-const ALCHEMY_GOERLI_ID = process.env.REACT_APP_ALCHEMY_GOERLI_ID || process.env.ALCHEMY_GOERLI_ID
-const ALCHEMY_KOVAN_ID = process.env.REACT_APP_ALCHEMY_KOVAN_ID || process.env.ALCHEMY_KOVAN_ID
-
-const ALCHEMY_ID = (N => {
-  switch (N) {
-    case RINKEBY_ID:
-      return ALCHEMY_RINKEBY_ID
-    case MAIN_ID:
-      return ALCHEMY_MAINNET_ID
-    case GOERLI_ID:
-      return ALCHEMY_GOERLI_ID
-    case KOVAN_ID:
-      return ALCHEMY_KOVAN_ID
-    default:
-  }
-})(NETWORK)
-
-const RADAR_DEPLOY_ID = (N => {
-  switch (N) {
-    case RINKEBY_ID:
-      return 'a488753ac102fd75b2124ed4ef7f80d91f34aa42ac6edd1a'
-    case MAIN_ID:
-      return '728fe3acec3dab0d119020f8afad5b4977283091eac1218a'
-    case GOERLI_ID:
-      return ''
-    case KOVAN_ID:
-      return ''
-    default:
-  }
-})(NETWORK)
-
-const RADAR_DEPLOY_NODE = (N => {
-  switch (N) {
-    case RINKEBY_ID:
-      return 'gethrinkeby1586077392610'
-    case MAIN_ID:
-      return 'gethmainnet1586077331438'
-    case GOERLI_ID:
-      return ''
-    case KOVAN_ID:
-      return ''
-    default:
-  }
-})(NETWORK)
-
-const RADAR_DEPLOY_URL = RADAR_DEPLOY_ID
-  ? `https://${RADAR_DEPLOY_NODE}.nodes.deploy.radar.tech/?apikey=${RADAR_DEPLOY_ID}`
-  : ''
-
-const RADAR_DEPLOY_WEBSOCKET = RADAR_DEPLOY_ID
-  ? `wss://${RADAR_DEPLOY_NODE}.nodes.deploy.radar.tech/ws?apikey=${RADAR_DEPLOY_ID}`
-  : ''
-
-const ALCHEMY_WEBSOCKET_URL = ALCHEMY_ID
-  ? `wss://eth-${NETWORK_MAPPING[NETWORK].toLowerCase()}.ws.alchemyapi.io/v2/${ALCHEMY_ID}`
-  : ''
-
-const INFURA_ID = '9882544d7b8f441b8e5a6890b837f6e9'
-
-const INFURA_GETH_NODE = (N => {
-  switch (N) {
-    case RINKEBY_ID:
-      return `https://rinkeby.infura.io/v3/${INFURA_ID}`
-    case MAIN_ID:
-      return `https://mainnet.infura.io/v3/${INFURA_ID}`
-    case GOERLI_ID:
-      return `https://goerli.infura.io/v3/${INFURA_ID}`
-    case KOVAN_ID:
-      return `https://kovan.infura.io/v3/${INFURA_ID}`
-    default:
-  }
-})(NETWORK)
-
-const INFURA_WEBSOCKET = (N => {
-  switch (N) {
-    case RINKEBY_ID:
-      return `wss://rinkeby.infura.io/ws/v3/${INFURA_ID}`
-    case MAIN_ID:
-      return `wss://mainnet.infura.io/ws/v3/${INFURA_ID}`
-    case GOERLI_ID:
-      return `wss://goerli.infura.io/ws/v3/${INFURA_ID}`
-    case KOVAN_ID:
-      return `wss://kovan.infura.io/ws/v3/${INFURA_ID}`
-    default:
-  }
-})(NETWORK)
-
-const websocketOptions = {
-  // Enable auto reconnection
-  reconnect: {
-    auto: true,
-    delay: 5000, // ms
-    maxAttempts: 100,
-    onTimeout: false,
-  },
-}
-
-const web3Provider = ALCHEMY_ID
-  ? new Web3(new Web3.providers.WebsocketProvider(ALCHEMY_WEBSOCKET_URL, websocketOptions))
-  : new Web3(new Web3.providers.WebsocketProvider(INFURA_WEBSOCKET, websocketOptions))
-// this doesn't appear to work for some reason, will investigate another time
-// call to deltabalances contracts were never sent in the websocket when I tried to use the web3 websocket as the provider for ethers
-// no errors were thrown, the calls just never showed up in the network tab even though the functions were being called
-// const ethersProvider = new ethers.providers.Web3Provider(web3Provider.currentProvider)
-
-let JSON_RPC_URL = ALCHEMY_ID
-  ? `https://eth-${NETWORK_MAPPING[NETWORK].toLowerCase()}.alchemyapi.io/v2/${ALCHEMY_ID}`
-  : INFURA_GETH_NODE
-
-if (process.env.JSON_RPC_URL) {
-  JSON_RPC_URL = process.env.JSON_RPC_URL
-}
-
-if (process.env.REACT_APP_JSON_RPC_URL) {
-  JSON_RPC_URL = process.env.REACT_APP_JSON_RPC_URL
-}
-
-if (process.env.MOCHA_IS_TESTING || process.env.REACT_APP_TESTING) {
-  JSON_RPC_URL = 'http://localhost:8545'
-}
-
-const ethersProvider = new RetryProvider(JSON_RPC_URL, NETWORK)
 
 const INDEXER_ADDRESS = ETH_ADDRESS
 
@@ -535,7 +471,8 @@ const PROTOCOL_1 = '0x0001'
 const PROTOCOL_2 = '0x0002'
 
 module.exports = {
-  JSON_RPC_URL,
+  ETH_NODE_HTTP,
+  ETH_NODE_WEBSOCKET,
   ENV,
   MAIN_ID,
   RINKEBY_ID,
@@ -558,7 +495,6 @@ module.exports = {
   WETH_CONTRACT_ADDRESS,
   DAI_CONTRACT_ADDRESS,
   DELTA_BALANCES_CONTRACT_ADDRESS,
-  INFURA_GETH_NODE,
   abis,
   TOKEN_APPROVAL_AMOUNT,
   TOKEN_APPROVAL_CHECK_AMOUNT,
@@ -589,7 +525,6 @@ module.exports = {
   ethersProvider,
   WRAPPER_CONTRACT_ADDRESS,
   INFINITE_EXPIRY,
-  ALCHEMY_WEBSOCKET_URL,
   web3Provider,
   INDEXER_CONTRACT_ADDRESS,
   DELEGATE_FACTORY_CONTRACT_ADDRESS,
@@ -600,8 +535,5 @@ module.exports = {
   PROTOCOL_1,
   PROTOCOL_2,
   NO_ALCHEMY_WEBSOCKETS,
-  ALCHEMY_ID,
-  RADAR_DEPLOY_URL,
-  RADAR_DEPLOY_WEBSOCKET,
   USDC_CONTRACT_ADDRESS,
 }

--- a/src/deltaBalances/index.js
+++ b/src/deltaBalances/index.js
@@ -10,12 +10,10 @@ const {
   ETH_ADDRESS,
 } = require('../constants')
 
-const defaultProvider = ethersProvider
-
 const deltaBalancesContract = new ethers.Contract(
   DELTA_BALANCES_CONTRACT_ADDRESS,
   abis[DELTA_BALANCES_CONTRACT_ADDRESS],
-  defaultProvider,
+  ethersProvider,
 )
 
 function getManyBalancesManyAddresses(tokens, addresses) {

--- a/src/tokens/index.js
+++ b/src/tokens/index.js
@@ -4,7 +4,15 @@ const _ = require('lodash')
 const TokenMetadata = require('@airswap/metadata').default
 const { tokenKindNames } = require('@airswap/constants')
 
-const { NETWORK, RINKEBY_ID, MAIN_ID, GOERLI_ID, KOVAN_ID, BASE_ASSET_TOKEN_ADDRESSES } = require('../constants')
+const {
+  ethersProvider,
+  NETWORK,
+  RINKEBY_ID,
+  MAIN_ID,
+  GOERLI_ID,
+  KOVAN_ID,
+  BASE_ASSET_TOKEN_ADDRESSES,
+} = require('../constants')
 const { flatten } = require('../swap/utils')
 
 const TOKEN_METADATA_BASE_URL = 'https://token-metadata.airswap.io'
@@ -92,7 +100,7 @@ function mapToOldMetadataSchema(metadata) {
 
 class OldTokenMetadata {
   constructor() {
-    const metadataPkg = new TokenMetadata(NETWORK)
+    const metadataPkg = new TokenMetadata(ethersProvider)
     this.ready = Promise.all([metadataPkg.ready, fetchAirswapTokens()]).then(([tokens, airswapTokens]) => {
       const newTokens = _.uniqBy([...airswapTokens, ...tokens.map(mapToOldMetadataSchema)], 'address')
       this.setTokens(newTokens)

--- a/src/utils/contractAddresses.js
+++ b/src/utils/contractAddresses.js
@@ -6,12 +6,10 @@ const ethers = require('ethers')
 const rlp = require('rlp')
 const keccak = require('keccak')
 const _ = require('lodash')
-const { NETWORK_NAME } = require('../constants')
-
-const provider = ethers.getDefaultProvider(NETWORK_NAME)
+const { ethersProvider } = require('../constants')
 
 async function findDeployedContractsForSender(sender, bytecode) {
-  const transactionCount = await provider.getTransactionCount(sender)
+  const transactionCount = await ethersProvider.getTransactionCount(sender)
   const nonces = _.range(0, transactionCount)
   const contracts = []
   // now I iterate over it
@@ -26,7 +24,7 @@ async function findDeployedContractsForSender(sender, bytecode) {
         .digest('hex')
 
       const contract_address = `0x${contract_address_long.substring(24)}` // Trim the first 24 characters.
-      const code = await provider.getCode(contract_address)
+      const code = await ethersProvider.getCode(contract_address)
       if (code.replace(/^\s+|\s+$/g, '') === bytecode) {
         contracts.push({ intNonce, address: contract_address })
       }

--- a/src/utils/ethereumDatetime.js
+++ b/src/utils/ethereumDatetime.js
@@ -1,7 +1,7 @@
 const ethers = require('ethers')
-const { JSON_RPC_URL } = require('../constants')
+const { ETH_NODE_HTTP } = require('../constants')
 
-const provider = new ethers.providers.JsonRpcProvider(JSON_RPC_URL)
+const provider = new ethers.providers.JsonRpcProvider(ETH_NODE_HTTP)
 
 const blocks = {}
 

--- a/src/utils/revertReason.js
+++ b/src/utils/revertReason.js
@@ -1,8 +1,4 @@
-const { NETWORK_NAME } = require('../constants')
-
-const ethers = require('ethers')
-
-const provider = new ethers.getDefaultProvider(NETWORK_NAME || 'homestead')
+const { ethersProvider } = require('../constants')
 
 function hex_to_ascii(str1) {
   const hex = str1.toString()
@@ -14,11 +10,11 @@ function hex_to_ascii(str1) {
 }
 
 async function getRevertReason(hash) {
-  const tx = await provider.getTransaction(hash)
+  const tx = await ethersProvider.getTransaction(hash)
   if (!tx) {
     console.log('tx not found')
   } else {
-    const code = await provider.call(tx, tx.blockNumber)
+    const code = await ethersProvider.call(tx, tx.blockNumber)
     return hex_to_ascii(code.substr(138))
   }
 }

--- a/src/wallet/redux/middleware.js
+++ b/src/wallet/redux/middleware.js
@@ -9,7 +9,7 @@ import { selectors as gasSelectors } from '../../gas/redux'
 import { selectors as walletSelectors } from './reducers'
 import getSigner from '../getSigner'
 import { formatErrorMessage, getParsedInputFromTransaction } from '../../utils/transformations'
-import { PORTIS_ID, AIRSWAP_LOGO_URL, JSON_RPC_URL, NETWORK, FORTMATIC_ID } from '../../constants'
+import { PORTIS_ID, AIRSWAP_LOGO_URL, ETH_NODE_HTTP, NETWORK, FORTMATIC_ID } from '../../constants'
 
 import { web3WalletTypes } from '../static/constants'
 import { connectWallet } from './actions'
@@ -157,7 +157,7 @@ function connectPrivateKey(store) {
 
 function connectPortis(store) {
   const portisConfig = {
-    nodeUrl: JSON_RPC_URL,
+    nodeUrl: ETH_NODE_HTTP,
     chainId: NETWORK,
     nodeProtocol: 'rpc',
   }
@@ -193,7 +193,7 @@ function connectWalletLink(store, walletAppLogo, walletAppName) {
     appLogoUrl: walletAppLogo || AIRSWAP_LOGO_URL,
   })
 
-  const provider = walletLink.makeWeb3Provider(JSON_RPC_URL, NETWORK)
+  const provider = walletLink.makeWeb3Provider(ETH_NODE_HTTP, NETWORK)
   provider.enable().then(() => {
     signer = getSigner({ web3Provider: provider }, walletActions)
     const addressPromise = signer.getAddress()

--- a/src/wallet/uncheckedJsonRpcSigner.js
+++ b/src/wallet/uncheckedJsonRpcSigner.js
@@ -1,9 +1,7 @@
 const ethers = require('ethers')
-const { NETWORK_NAME, ethersProvider } = require('../constants')
+const { ethersProvider } = require('../constants')
 const { poll } = require('ethers/utils/web')
 // const { checkProperties, defineReadOnly, resolveProperties, shallowCopy } = require('ethers/utils/properties')
-
-const provider = new ethers.getDefaultProvider(NETWORK_NAME || 'homestead')
 
 // from: https://github.com/ethers-io/ethers.js/issues/340#issuecomment-447512944
 class UncheckedJsonRpcSigner extends ethers.Signer {
@@ -24,11 +22,6 @@ class UncheckedJsonRpcSigner extends ethers.Signer {
       poll(
         async () => {
           let tx
-          tx = await provider.getTransaction(hash)
-          if (tx) {
-            console.log('ethers default provider found transaction')
-            return tx
-          }
           tx = await this.signer.provider.getTransaction(hash)
           if (tx) {
             console.log('window.web3 injected provider found transaction')
@@ -36,7 +29,7 @@ class UncheckedJsonRpcSigner extends ethers.Signer {
           }
           tx = await ethersProvider.getTransaction(hash)
           if (tx) {
-            console.log('airswap found transaction')
+            console.log('ethers provider found transaction')
             return tx
           }
           console.log(`failed to find ${hash}`)


### PR DESCRIPTION
Rather than figuring out a provider URL based on a variety of API keys (hard coded or env variables), this change just takes `ETH_NODE_HTTP` and `ETH_NODE_WEBSOCKET` from the host application environment. If those are not set, default providers are used.